### PR TITLE
Remove erroneous slash in shebang

### DIFF
--- a/useful_scripts/prepend_python_shebang.sh
+++ b/useful_scripts/prepend_python_shebang.sh
@@ -9,7 +9,7 @@
 
 # prepends !#/usr/bin/python to all .py files
 find ./ -maxdepth 1 -name "*.py" -exec sed -i.bak '1i\
-#!/usr/bin/env/python
+#!/usr/bin/env python
 ' {} \;
 
 # removes temporary files


### PR DESCRIPTION
In general, it's better to use `env` instead of determining the path to the Python executable by Bash's `which` command. The latter produces unexpected results with aliases, otherwise it is equivalent to the former.

`#!/usr/bin/env python` is widely used.
