### PR TITLE
Fixed 2 typos (1 important)

### DIFF
--- a/tutorials/scope_resolution_legb_rule.ipynb
+++ b/tutorials/scope_resolution_legb_rule.ipynb
@@ -253,7 +253,7 @@
      "source": [
       "### Tip:\n",
       "If we want to print out the dictionary mapping of the global and local variables, we can use the\n",
-      "the functions `global()` and `local()"
+      "the functions `global()` and `local()`"
      ]
     },
     {
@@ -951,7 +951,7 @@
      "cell_type": "code",
      "collapsed": false,
      "input": [
-      "print('Example 1.2:', chr(int('01100001',2)))"
+      "print('Example 1.2:', chr(int('01100010',2)))"
      ],
      "language": "python",
      "metadata": {},


### PR DESCRIPTION
Fixed a type causing a code tag not to be formatted correctly, and fixed the answer of Example 1.2 to be 'b' instead of 'a' (which is the text's intent, I believe)

This is a minuscule commit but I'm new to open source so let me know if I've done anything wrong, thanks! 
