### PR TITLE
docs: Fix a few typos

### DIFF
--- a/tutorials/installing_scientific_packages.md
+++ b/tutorials/installing_scientific_packages.md
@@ -278,7 +278,7 @@ print its path:
     
 
 Finally, we can set an `alias` in our `.bash_profile` or `.bash_rc` file to
-conviniently run IPython from the console. E.g.,
+conveniently run IPython from the console. E.g.,
 
     
     

--- a/tutorials/sqlite3_howto/README.md
+++ b/tutorials/sqlite3_howto/README.md
@@ -586,7 +586,7 @@ syntax applies to simple dates or simple times only, too.
 #### Update Mar 16, 2014:
 
   
-If'd we are interested to calulate the hours between two `DATETIME()`
+If'd we are interested to calculate the hours between two `DATETIME()`
 timestamps, we can could use the handy `STRFTIME()` function like this  
   
 

--- a/tutorials/sqlite3_howto/code/update_or_insert_records.py
+++ b/tutorials/sqlite3_howto/code/update_or_insert_records.py
@@ -1,6 +1,6 @@
 # Sebastian Raschka, 2014
 # Update records or insert them if they don't exist.
-# Note that this is a workaround to accomodate for missing
+# Note that this is a workaround to accommodate for missing
 # SQL features in SQLite.
 
 import sqlite3

--- a/useful_scripts/conc_gzip_files.py
+++ b/useful_scripts/conc_gzip_files.py
@@ -13,7 +13,7 @@ def conc_gzip_files(in_dir, out_file, append=False, print_progress=True):
     Keyword arguments:
         in_dir (str): Path of the directory with the gzip-files
         out_file (str): Path to the resulting file
-        append (bool): If true, it appends contents to an exisiting file,
+        append (bool): If true, it appends contents to an existing file,
              else creates a new output file.
         print_progress (bool): prints progress bar if true.
 


### PR DESCRIPTION
There are small typos in:
- tutorials/installing_scientific_packages.md
- tutorials/sqlite3_howto/README.md
- tutorials/sqlite3_howto/code/update_or_insert_records.py
- useful_scripts/conc_gzip_files.py

Fixes:
- Should read `existing` rather than `exisiting`.
- Should read `conveniently` rather than `conviniently`.
- Should read `calculate` rather than `calulate`.
- Should read `accommodate` rather than `accomodate`.



Semi-automated pull request generated by
https://github.com/timgates42/meticulous/blob/master/docs/NOTE.md